### PR TITLE
Fix NEP-21 multisig signatureOnly signer resolution

### DIFF
--- a/cross-runtime/neo3-signing.ts
+++ b/cross-runtime/neo3-signing.ts
@@ -10,8 +10,15 @@ type AccountLike = {
   };
 };
 
+type SignerAccountLike =
+  | string
+  | {
+      toBigEndian?: () => string;
+      toString?: () => string;
+    };
+
 type SignerLike = {
-  account?: any;
+  account?: SignerAccountLike;
 };
 
 export type Neo3TransactionSignerMatch = {
@@ -23,7 +30,7 @@ export type Neo3TransactionSignerMatch = {
   publicKey?: string;
 };
 
-export function normalizeNeo3SignerHash(hash: any): string {
+export function normalizeNeo3SignerHash(hash: unknown): string {
   return String(hash || '')
     .replace(/^0x/i, '')
     .toLowerCase();
@@ -66,10 +73,11 @@ export function getNeo3ContractHash(contractScript?: string) {
 }
 
 function getTransactionSignerHash(signer: SignerLike) {
+  const signerAccount = signer?.account;
   return normalizeNeo3SignerHash(
-    signer?.account?.toBigEndian?.() ??
-      signer?.account?.toString?.() ??
-      signer?.account,
+    typeof signerAccount === 'string'
+      ? signerAccount
+      : signerAccount?.toBigEndian?.() ?? signerAccount?.toString?.(),
   );
 }
 
@@ -83,9 +91,10 @@ export function resolveNeo3TransactionSigner(params: {
     params.account?.contract?.script,
   );
   const contractHash = getNeo3ContractHash(params.account?.contract?.script);
-  const candidateHashes = [accountHash, contractHash].filter(
-    (hash, index, hashes) => !!hash && hashes.indexOf(hash) === index,
-  );
+  const candidateHashes = [accountHash];
+  if (contractHash && contractHash !== accountHash) {
+    candidateHashes.push(contractHash);
+  }
   if (candidateHashes.length === 0) {
     return null;
   }

--- a/cross-runtime/neo3-signing.ts
+++ b/cross-runtime/neo3-signing.ts
@@ -1,0 +1,114 @@
+import { wallet } from '@cityofzion/neon-core-neo3/lib';
+
+type AccountLike = {
+  address?: string;
+  contract?: {
+    script?: string;
+  };
+  extra?: {
+    publicKey?: string;
+  };
+};
+
+type SignerLike = {
+  account?: any;
+};
+
+export type Neo3TransactionSignerMatch = {
+  accountHash: string;
+  contractHash: string;
+  signerHash: string;
+  verificationScript: string;
+  usesContractSigner: boolean;
+  publicKey?: string;
+};
+
+export function normalizeNeo3SignerHash(hash: any): string {
+  return String(hash || '')
+    .replace(/^0x/i, '')
+    .toLowerCase();
+}
+
+export function decodeNeo3VerificationScript(script?: string) {
+  if (!script) {
+    return '';
+  }
+
+  const normalized = script.startsWith('0x') ? script.slice(2) : script;
+  if (/^[0-9a-fA-F]+$/.test(normalized) && normalized.length % 2 === 0) {
+    return normalized;
+  }
+
+  return Buffer.from(script, 'base64').toString('hex');
+}
+
+export function getNeo3AccountHash(address?: string) {
+  if (!address) {
+    return '';
+  }
+
+  return normalizeNeo3SignerHash(wallet.getScriptHashFromAddress(address));
+}
+
+export function getNeo3ContractHash(contractScript?: string) {
+  const verificationScript = decodeNeo3VerificationScript(contractScript);
+  if (!verificationScript) {
+    return '';
+  }
+
+  try {
+    return normalizeNeo3SignerHash(
+      wallet.getScriptHashFromVerificationScript(verificationScript),
+    );
+  } catch (_) {
+    return '';
+  }
+}
+
+function getTransactionSignerHash(signer: SignerLike) {
+  return normalizeNeo3SignerHash(
+    signer?.account?.toBigEndian?.() ??
+      signer?.account?.toString?.() ??
+      signer?.account,
+  );
+}
+
+export function resolveNeo3TransactionSigner(params: {
+  account?: AccountLike;
+  signers?: SignerLike[];
+  contextItems?: Record<string, unknown>;
+}): Neo3TransactionSignerMatch | null {
+  const accountHash = getNeo3AccountHash(params.account?.address);
+  const verificationScript = decodeNeo3VerificationScript(
+    params.account?.contract?.script,
+  );
+  const contractHash = getNeo3ContractHash(params.account?.contract?.script);
+  const candidateHashes = [accountHash, contractHash].filter(
+    (hash, index, hashes) => !!hash && hashes.indexOf(hash) === index,
+  );
+  if (candidateHashes.length === 0) {
+    return null;
+  }
+
+  const signerHashes = new Set(
+    (params.signers || []).map(getTransactionSignerHash).filter(Boolean),
+  );
+  const matchingHashes = candidateHashes.filter((hash) => signerHashes.has(hash));
+  if (matchingHashes.length === 0) {
+    return null;
+  }
+
+  const signerHash =
+    matchingHashes.find((hash) =>
+      Object.prototype.hasOwnProperty.call(params.contextItems || {}, hash),
+    ) || matchingHashes[0];
+
+  return {
+    accountHash,
+    contractHash,
+    signerHash,
+    verificationScript,
+    usesContractSigner: signerHash === contractHash && contractHash !== accountHash,
+    publicKey: params.account?.extra?.publicKey,
+  };
+}

--- a/extension/background/tool.ts
+++ b/extension/background/tool.ts
@@ -280,5 +280,9 @@ export function canCurrentWalletSignTransaction(parameter: any, currentWallet: W
     return !!parameter.context.items[currentSigner.signerHash];
   }
 
+  if (currentSigner.usesContractSigner && !parameter?.context) {
+    return false;
+  }
+
   return true;
 }

--- a/extension/background/tool.ts
+++ b/extension/background/tool.ts
@@ -14,10 +14,11 @@ import {
   setLocalStorage,
   setStorage,
 } from '../common';
-import { getScriptHashFromAddress, getWalletType } from '../common/utils';
+import { getWalletType } from '../common/utils';
 import { EVENT } from '../common/data_module_neo2';
 import { Wallet3 } from '../common/data_module_neo3';
 import { tx as tx3} from '@cityofzion/neon-core-neo3/lib';
+import { resolveNeo3TransactionSigner } from '../../cross-runtime/neo3-signing';
 
 /**
  * Background methods support.
@@ -239,12 +240,6 @@ export function findNetworkConfigurationBy(
   return networkConfiguration || null;
 }
 
-function normalizeSignerHash(hash: any) {
-  return String(hash || '')
-    .replace(/^0x/i, '')
-    .toLowerCase();
-}
-
 function deserializeSignTransactionPayload(parameter: any) {
   if (parameter?.context?.data) {
     try {
@@ -266,23 +261,23 @@ function deserializeSignTransactionPayload(parameter: any) {
 }
 
 export function canCurrentWalletSignTransaction(parameter: any, currentWallet: Wallet3) {
-  const currentAddress = currentWallet?.accounts?.[0]?.address;
-  if (!currentAddress) {
+  const currentAccount = currentWallet?.accounts?.[0];
+  if (!currentAccount) {
     return false;
   }
 
-  const currentHash = normalizeSignerHash(getScriptHashFromAddress(currentAddress));
   const transaction = deserializeSignTransactionPayload(parameter);
-  const hasSigner = (transaction.signers || []).some(
-    (signer) => normalizeSignerHash(signer.account?.toBigEndian?.()) === currentHash
-  );
-
-  if (!hasSigner) {
+  const currentSigner = resolveNeo3TransactionSigner({
+    account: currentAccount,
+    signers: transaction.signers || [],
+    contextItems: parameter?.context?.items,
+  });
+  if (!currentSigner) {
     return false;
   }
 
   if (parameter?.context?.items) {
-    return !!parameter.context.items[currentHash];
+    return !!parameter.context.items[currentSigner.signerHash];
   }
 
   return true;

--- a/src/app/popup/notification/neo3-sign-transaction/neo3-sign-transaction.component.ts
+++ b/src/app/popup/notification/neo3-sign-transaction/neo3-sign-transaction.component.ts
@@ -10,6 +10,7 @@ import { Store } from '@ngrx/store';
 import { AppState } from '@/app/reduers';
 import { Unsubscribable } from 'rxjs';
 import { Wallet3 } from '@popup/_lib';
+import { resolveNeo3TransactionSigner } from '@cross-runtime/neo3-signing';
 import {
   buildSignedContext,
   ContractParametersContextLike,
@@ -142,29 +143,6 @@ export class PopupNoticeNeo3SignTransactionComponent implements OnInit {
     );
   }
 
-  private normalizeScriptHash(hash: any): string {
-    return String(hash || '')
-      .replace(/^0x/i, '')
-      .toLowerCase();
-  }
-
-  private getSignerAccountHash(signer: any): string {
-    if (!signer) {
-      return '';
-    }
-    const signerHash =
-      signer?.account?.toBigEndian?.() ??
-      signer?.account?.toString?.() ??
-      signer?.account;
-    return this.normalizeScriptHash(signerHash);
-  }
-
-  private getCurrentWalletAccountHash() {
-    return this.normalizeScriptHash(
-      wallet.getScriptHashFromAddress(this.currentWallet.accounts[0].address),
-    );
-  }
-
   private sendNotSignableError(description: string) {
     this.clearStoredParams();
     this.chrome.windowCallback(
@@ -186,21 +164,39 @@ export class PopupNoticeNeo3SignTransactionComponent implements OnInit {
       return null;
     }
 
-    const currentAccountHash = this.getCurrentWalletAccountHash();
-    const isSigner = (this.tx.signers || []).some(
-      (signer) => this.getSignerAccountHash(signer) === currentAccountHash,
-    );
-    if (!isSigner) {
+    const currentSigner = resolveNeo3TransactionSigner({
+      account: this.currentWallet.accounts[0],
+      signers: this.tx.signers || [],
+      contextItems: this.context?.items,
+    });
+    if (!currentSigner) {
       this.sendNotSignableError(
         'Current account is not a signer in this transaction',
       );
       return null;
     }
 
-    return {
-      accountHash: currentAccountHash,
-      publicKey: this.currentWallet.accounts[0]?.extra?.publicKey,
-    };
+    if (
+      this.context?.items &&
+      !Object.prototype.hasOwnProperty.call(
+        this.context.items,
+        currentSigner.signerHash,
+      )
+    ) {
+      this.sendNotSignableError(
+        'Current account is not a signer in this transaction context',
+      );
+      return null;
+    }
+
+    if (currentSigner.usesContractSigner && !this.signatureOnly) {
+      this.sendNotSignableError(
+        'Multisig transaction signing requires a transaction context',
+      );
+      return null;
+    }
+
+    return currentSigner;
   }
 
   private sendSignedContext(signature: string, publicKey: string) {

--- a/src/app/popup/notification/neo3-sign-transaction/neo3-sign-transaction.util.spec.ts
+++ b/src/app/popup/notification/neo3-sign-transaction/neo3-sign-transaction.util.spec.ts
@@ -1,0 +1,97 @@
+import { tx, wallet } from '@cityofzion/neon-core-neo3/lib';
+import { getNeo3ContractHash } from '@cross-runtime/neo3-signing';
+import {
+  buildContractParametersContext,
+  buildSignedContext,
+} from './neo3-sign-transaction.util';
+
+describe('neo3-sign-transaction util', () => {
+  const networkMagic = 860833102;
+  const memberPrivateKey = '1'.repeat(64);
+  const cosignerPrivateKey = '2'.repeat(64);
+
+  function createMultisigSigningFixture() {
+    const memberAccount = new wallet.Account(memberPrivateKey);
+    const cosignerAccount = new wallet.Account(cosignerPrivateKey);
+    const multisigAccount = wallet.Account.createMultiSig(2, [
+      memberAccount.publicKey,
+      cosignerAccount.publicKey,
+    ]);
+    const contractHash = getNeo3ContractHash(multisigAccount.contract.script);
+    const transaction = new tx.Transaction({
+      signers: [
+        {
+          account: contractHash,
+          scopes: tx.WitnessScope.CalledByEntry,
+        },
+      ],
+      validUntilBlock: 123,
+      script: '11',
+    });
+    const walletAccount = {
+      address: memberAccount.address,
+      contract: multisigAccount.contract,
+      extra: {
+        publicKey: memberAccount.publicKey,
+      },
+    };
+
+    return {
+      contractHash,
+      memberAccount,
+      transaction,
+      walletAccount,
+    };
+  }
+
+  it('builds context items for the multisig contract when the wallet address is a member address', () => {
+    const { contractHash, transaction, walletAccount } =
+      createMultisigSigningFixture();
+
+    const context = buildContractParametersContext(
+      transaction.serialize(true),
+      networkMagic,
+      {},
+      walletAccount,
+    );
+
+    expect(context.items[contractHash].script).toBe(
+      walletAccount.contract.script,
+    );
+    expect(context.items[contractHash].parameters.length).toBe(2);
+    expect(context.items[contractHash].parameters[0].type).toBe('Signature');
+  });
+
+  it('records a member signature on the multisig contract hash for signatureOnly signing', () => {
+    const { contractHash, memberAccount, transaction, walletAccount } =
+      createMultisigSigningFixture();
+    const context = buildContractParametersContext(
+      transaction.serialize(true),
+      networkMagic,
+      {},
+      walletAccount,
+    );
+    const signature = wallet.sign(
+      transaction.getMessageForSigning(networkMagic),
+      memberPrivateKey,
+    );
+    const signatureBase64 = Buffer.from(signature, 'hex').toString('base64');
+
+    const signedContext = buildSignedContext({
+      context,
+      account: walletAccount,
+      publicKey: memberAccount.publicKey,
+      signature,
+    });
+
+    expect(
+      signedContext.items[contractHash].signatures[memberAccount.publicKey],
+    ).toBe(signatureBase64);
+    expect(signedContext.items[contractHash].parameters[0].value).toBe(
+      signatureBase64,
+    );
+    expect(signedContext.items[contractHash].script).toBe(
+      walletAccount.contract.script,
+    );
+  });
+});

--- a/src/app/popup/notification/neo3-sign-transaction/neo3-sign-transaction.util.ts
+++ b/src/app/popup/notification/neo3-sign-transaction/neo3-sign-transaction.util.ts
@@ -1,4 +1,5 @@
 import { tx, wallet } from '@cityofzion/neon-core-neo3/lib';
+import { resolveNeo3TransactionSigner } from '@cross-runtime/neo3-signing';
 
 type ContextArgument = {
   name?: string;
@@ -39,12 +40,6 @@ type AccountLike = {
 
 function stripHexPrefix(value: string) {
   return value.startsWith('0x') ? value.slice(2) : value;
-}
-
-function normalizeContextAccountHash(hash?: string) {
-  return String(hash || '')
-    .replace(/^0x/i, '')
-    .toLowerCase();
 }
 
 function hex2base64(value: string) {
@@ -110,13 +105,17 @@ function buildContextParameters(
     verificationScript,
     signatures
   );
+  const normalizedSeedParameters = (seedParameters || []).filter(Boolean);
+  const normalizedContractParameters = (contractParameters || [])
+    .filter(Boolean)
+    .map((parameter) => ({
+      name: parameter.name,
+      type: parameter.type,
+    }));
   const template =
-    seedParameters.length > 0
-      ? seedParameters
-      : contractParameters.map((parameter) => ({
-          name: parameter.name,
-          type: parameter.type,
-        }));
+    normalizedSeedParameters.length > 0
+      ? normalizedSeedParameters
+      : normalizedContractParameters;
 
   if (template.length > 0) {
     return template.map((parameter, index) => ({
@@ -211,16 +210,22 @@ function applyContextItemsToTransaction(
   context: ContractParametersContextLike,
   account?: AccountLike
 ) {
-  const accountHash = account
-    ? normalizeContextAccountHash(wallet.getScriptHashFromAddress(account.address))
-    : '';
+  const accountSigner = account
+    ? resolveNeo3TransactionSigner({
+        account,
+        signers: transaction.signers,
+        contextItems: context.items,
+      })
+    : null;
 
   transaction.signers.forEach((signer) => {
     const signerHash = signer.account.toBigEndian();
     const item = context.items?.[signerHash];
     const verificationScript =
       decodeContextScript(item?.script) ||
-      (signerHash === accountHash ? decodeContextScript(account?.contract?.script) : '');
+      (signerHash === accountSigner?.signerHash
+        ? accountSigner.verificationScript
+        : '');
 
     if (!item || !verificationScript || !item.signatures) {
       return;
@@ -259,9 +264,13 @@ export function buildContractParametersContext(
   account?: AccountLike
 ): ContractParametersContextLike {
   const transaction = tx.Transaction.deserialize(stripHexPrefix(serializedTx));
-  const accountHash = account
-    ? normalizeContextAccountHash(wallet.getScriptHashFromAddress(account.address))
-    : '';
+  const accountSigner = account
+    ? resolveNeo3TransactionSigner({
+        account,
+        signers: transaction.signers,
+        contextItems: seedItems,
+      })
+    : null;
 
   const items = transaction.signers.reduce((acc, signer) => {
     const signerHash = signer.account.toBigEndian();
@@ -282,11 +291,8 @@ export function buildContractParametersContext(
       decodeContextScript(seedItem?.script)
     );
     const accountVerificationScript =
-      signerHash === accountHash
-        ? ensureSignerVerificationScript(
-            signerHash,
-            decodeContextScript(account?.contract?.script)
-          )
+      signerHash === accountSigner?.signerHash
+        ? ensureSignerVerificationScript(signerHash, accountSigner.verificationScript)
         : '';
     const verificationScript =
       witnessVerificationScript ||
@@ -321,7 +327,7 @@ export function buildContractParametersContext(
       parameters: buildContextParameters(
         verificationScript,
         verificationScript ? seedItem?.parameters : [],
-        signerHash === accountHash ? account?.contract?.parameters : [],
+        signerHash === accountSigner?.signerHash ? account?.contract?.parameters : [],
         signatures
       ),
       signatures,
@@ -344,17 +350,23 @@ export function buildSignedContext(params: {
   publicKey: string;
   signature: string;
 }) {
-  const accountHash = normalizeContextAccountHash(
-    wallet.getScriptHashFromAddress(params.account.address)
-  );
-  const signableItem = params.context.items?.[accountHash];
+  const transaction = deserializeContextTransaction(params.context);
+  const currentSigner = resolveNeo3TransactionSigner({
+    account: params.account,
+    signers: transaction.signers,
+    contextItems: params.context.items,
+  });
+  if (!currentSigner) {
+    throw new Error('Current account is not a signer in this transaction context');
+  }
+
+  const signableItem = params.context.items?.[currentSigner.signerHash];
   if (!signableItem) {
     throw new Error('Current account is not a signer in this transaction context');
   }
 
   const verificationScript =
-    decodeContextScript(signableItem.script) ||
-    decodeContextScript(params.account.contract?.script);
+    decodeContextScript(signableItem.script) || currentSigner.verificationScript;
   if (!verificationScript) {
     throw new Error('No verification script found for this transaction context');
   }
@@ -369,7 +381,7 @@ export function buildSignedContext(params: {
     : params.signature;
   const updatedItems = {
     ...params.context.items,
-    [accountHash]: {
+    [currentSigner.signerHash]: {
       ...signableItem,
       signatures: {
         ...(signableItem.signatures || {}),
@@ -379,7 +391,7 @@ export function buildSignedContext(params: {
   };
 
   const signedTransaction = applyContextItemsToTransaction(
-    deserializeContextTransaction(params.context),
+    transaction,
     {
       ...params.context,
       items: updatedItems,

--- a/src/app/popup/notification/neo3-sign-transaction/neo3-sign-transaction.util.ts
+++ b/src/app/popup/notification/neo3-sign-transaction/neo3-sign-transaction.util.ts
@@ -1,5 +1,8 @@
 import { tx, wallet } from '@cityofzion/neon-core-neo3/lib';
-import { resolveNeo3TransactionSigner } from '@cross-runtime/neo3-signing';
+import {
+  decodeNeo3VerificationScript,
+  resolveNeo3TransactionSigner,
+} from '@cross-runtime/neo3-signing';
 
 type ContextArgument = {
   name?: string;
@@ -44,19 +47,6 @@ function stripHexPrefix(value: string) {
 
 function hex2base64(value: string) {
   return Buffer.from(stripHexPrefix(value), 'hex').toString('base64');
-}
-
-function decodeContextScript(script?: string) {
-  if (!script) {
-    return '';
-  }
-
-  const normalized = stripHexPrefix(script);
-  if (/^[0-9a-fA-F]+$/.test(normalized) && normalized.length % 2 === 0) {
-    return normalized;
-  }
-
-  return Buffer.from(script, 'base64').toString('hex');
 }
 
 function ensureSignerVerificationScript(
@@ -222,7 +212,7 @@ function applyContextItemsToTransaction(
     const signerHash = signer.account.toBigEndian();
     const item = context.items?.[signerHash];
     const verificationScript =
-      decodeContextScript(item?.script) ||
+      decodeNeo3VerificationScript(item?.script) ||
       (signerHash === accountSigner?.signerHash
         ? accountSigner.verificationScript
         : '');
@@ -288,7 +278,7 @@ export function buildContractParametersContext(
     );
     const seedVerificationScript = ensureSignerVerificationScript(
       signerHash,
-      decodeContextScript(seedItem?.script)
+      decodeNeo3VerificationScript(seedItem?.script)
     );
     const accountVerificationScript =
       signerHash === accountSigner?.signerHash
@@ -366,7 +356,8 @@ export function buildSignedContext(params: {
   }
 
   const verificationScript =
-    decodeContextScript(signableItem.script) || currentSigner.verificationScript;
+    decodeNeo3VerificationScript(signableItem.script) ||
+    currentSigner.verificationScript;
   if (!verificationScript) {
     throw new Error('No verification script found for this transaction context');
   }

--- a/src/app/popup/notification/neo3-sign-transaction/neo3-signing.spec.ts
+++ b/src/app/popup/notification/neo3-sign-transaction/neo3-signing.spec.ts
@@ -1,0 +1,62 @@
+import { tx, wallet } from '@cityofzion/neon-core-neo3/lib';
+import {
+  getNeo3AccountHash,
+  getNeo3ContractHash,
+  resolveNeo3TransactionSigner,
+} from '@cross-runtime/neo3-signing';
+
+describe('resolveNeo3TransactionSigner', () => {
+  const memberPrivateKey = '1'.repeat(64);
+  const cosignerPrivateKey = '2'.repeat(64);
+
+  function createMultisigWalletAccount() {
+    const memberAccount = new wallet.Account(memberPrivateKey);
+    const cosignerAccount = new wallet.Account(cosignerPrivateKey);
+    const multisigAccount = wallet.Account.createMultiSig(2, [
+      memberAccount.publicKey,
+      cosignerAccount.publicKey,
+    ]);
+
+    return {
+      memberAccount,
+      multisigAccount,
+      walletAccount: {
+        address: memberAccount.address,
+        contract: multisigAccount.contract,
+        extra: {
+          publicKey: memberAccount.publicKey,
+        },
+      },
+    };
+  }
+
+  it('matches the multisig contract signer for signatureOnly contexts', () => {
+    const { walletAccount, memberAccount, multisigAccount } =
+      createMultisigWalletAccount();
+    const contractHash = getNeo3ContractHash(multisigAccount.contract.script);
+    const accountHash = getNeo3AccountHash(memberAccount.address);
+    const transaction = new tx.Transaction({
+      signers: [
+        {
+          account: contractHash,
+          scopes: tx.WitnessScope.CalledByEntry,
+        },
+      ],
+      validUntilBlock: 123,
+      script: '11',
+    });
+
+    const match = resolveNeo3TransactionSigner({
+      account: walletAccount,
+      signers: transaction.signers,
+      contextItems: {
+        [contractHash]: {},
+      },
+    });
+
+    expect(accountHash).not.toBe(contractHash);
+    expect(match?.signerHash).toBe(contractHash);
+    expect(match?.usesContractSigner).toBeTrue();
+    expect(match?.publicKey).toBe(memberAccount.publicKey);
+  });
+});

--- a/src/app/popup/notification/neo3-sign-transaction/neo3-signing.spec.ts
+++ b/src/app/popup/notification/neo3-sign-transaction/neo3-signing.spec.ts
@@ -59,4 +59,26 @@ describe('resolveNeo3TransactionSigner', () => {
     expect(match?.usesContractSigner).toBeTrue();
     expect(match?.publicKey).toBe(memberAccount.publicKey);
   });
+
+  it('returns null when neither the account hash nor the contract hash matches', () => {
+    const { walletAccount } = createMultisigWalletAccount();
+    const transaction = new tx.Transaction({
+      signers: [
+        {
+          account: 'f'.repeat(40),
+          scopes: tx.WitnessScope.CalledByEntry,
+        },
+      ],
+      validUntilBlock: 123,
+      script: '11',
+    });
+
+    const match = resolveNeo3TransactionSigner({
+      account: walletAccount,
+      signers: transaction.signers,
+      contextItems: {},
+    });
+
+    expect(match).toBeNull();
+  });
 });

--- a/src/app/popup/transfer/neo3-invoke.service.spec.ts
+++ b/src/app/popup/transfer/neo3-invoke.service.spec.ts
@@ -147,7 +147,9 @@ describe('Neo3InvokeService', () => {
         },
         error: (error) => {
           expect(error.type).toBe('RPC_ERROR');
-          expect(error.description).toBe('script error');
+          expect(error.description).toBe(
+            'An RPC error occurred when submitting the request'
+          );
           expect(error.data.state).toBe('FAULT');
           expect(error.data.error).toBe('script error');
           done();

--- a/src/app/popup/transfer/neo3-transfer.service.spec.ts
+++ b/src/app/popup/transfer/neo3-transfer.service.spec.ts
@@ -103,7 +103,11 @@ describe('Neo3TransferService', () => {
         },
         error: (error) => {
           expect(error.type).toBe('RPC_ERROR');
-          expect(error.description).toBe('script error');
+          expect(error.description).toBe(
+            'An RPC error occurred when submitting the request'
+          );
+          expect(error.data.state).toBe('FAULT');
+          expect(error.data.error).toBe('script error');
           done();
         },
       });
@@ -130,6 +134,9 @@ describe('Neo3TransferService', () => {
         error: (error) => {
           expect(error.type).toBe('INSUFFICIENT_FUNDS');
           expect(error.description).toBe(
+            'The user does not have a sufficient balance to perform the requested action'
+          );
+          expect(error.data).toBe(
             'Insufficient GAS to pay for fees! Required 0.00123556 but only had 0.001'
           );
           done();
@@ -157,7 +164,10 @@ describe('Neo3TransferService', () => {
         },
         error: (error) => {
           expect(error.type).toBe('INSUFFICIENT_FUNDS');
-          expect(error.description).toBe('Not enough balance 0.0018');
+          expect(error.description).toBe(
+            'The user does not have a sufficient balance to perform the requested action'
+          );
+          expect(error.data).toBe('Not enough balance 0.0018');
           done();
         },
       });
@@ -184,8 +194,9 @@ describe('Neo3TransferService', () => {
         error: (error) => {
           expect(error.type).toBe('INSUFFICIENT_FUNDS');
           expect(error.description).toBe(
-            'Insufficient balance when gas fee added 0.003'
+            'The user does not have a sufficient balance to perform the requested action'
           );
+          expect(error.data).toBe('Insufficient balance when gas fee added 0.003');
           done();
         },
       });


### PR DESCRIPTION
## Summary
- resolve Neo3 transaction signer ownership from either the wallet address hash or the wallet contract hash so NEP-21 multisig `signatureOnly` contexts can sign with imported member-address wallets
- reuse the same signer resolution in the popup guard, background precheck, and context signing utility so detached multisig signing succeeds consistently while raw multisig signing without context stays blocked
- add regression specs for multisig contract-hash signer matching and `signatureOnly` context signing, and normalize sparse multisig parameter templates emitted by neon-core

## Verification
- `node node_modules/@angular/cli/bin/ng.js lint`
- `node node_modules/@angular/cli/bin/ng.js test --watch=false --browsers=ChromeHeadless --include src/app/popup/notification/neo3-sign-transaction/neo3-signing.spec.ts --include src/app/popup/notification/neo3-sign-transaction/neo3-sign-transaction.util.spec.ts`

## Known baseline failures
- `node node_modules/typescript/bin/tsc -p tsconfig.json --noEmit` fails on an existing bad import in `src/app/popup/_dialogs/index.ts`
- `node node_modules/typescript/bin/tsc -p extension/tsconfig.json --noEmit` fails on existing `uuid` typings incompatible with the repo TypeScript baseline
- `node node_modules/@angular/cli/bin/ng.js test --watch=false --browsers=ChromeHeadless` still has 5 unrelated existing failures in `neo3-transfer.service.spec.ts` and `neo3-invoke.service.spec.ts`
